### PR TITLE
fix: escape \ character to fix incompatibility

### DIFF
--- a/tmux.conf
+++ b/tmux.conf
@@ -33,7 +33,7 @@ unbind C-b
 bind r source-file ~/.tmux.conf
 
 # Keymap
-bind \ split-window -h -c '#{pane_current_path}'
+bind \\ split-window -h -c '#{pane_current_path}'
 bind / split-window -v -c '#{pane_current_path}'
 unbind '"'
 unbind %


### PR DESCRIPTION
Em chào anh @codeaholicguy  ạ, 

Để bind được nút '\', character \ cần được escape trong file tmux config. Anh có thể xem thêm ở [đây](https://github.com/tmux/tmux/blob/master/CHANGES#L536) ạ. 